### PR TITLE
Including the <algorithm> standard library to fix a compilation error

### DIFF
--- a/src/common/i18n.cpp
+++ b/src/common/i18n.cpp
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <string>
 #include <map>
+#include <algorithm>
 #include "file_io_utils.h"
 #include "common/i18n.h"
 #include "translation_files.h"


### PR DESCRIPTION
There was an error when compiling with GCC 11.2.1 and glibc 2.33-r7 where 'std::transform' was not found.
To fix this error the library <algorithm> was included