### PR TITLE
Fix version regex validation.

### DIFF
--- a/src/rpc/rpc_version_str.cpp
+++ b/src/rpc/rpc_version_str.cpp
@@ -45,7 +45,7 @@ namespace rpc
 bool is_version_string_valid(const std::string& str)
 {
     return std::regex_match(str, std::regex(
-        "^\\d{1,2}(\\.\\d{1,2}){3}(-(release|[0-9a-f]{9}))?$",
+        "^\\d{1,2}(\\.\\d{1,2}){2}(-(release|[0-9a-f]{9}))?$",
         std::regex_constants::nosubs
     ));
 }


### PR DESCRIPTION
Using the command "version" in daemon console results in:
    Error: The daemon software version is not available.

Also, in src/wallet/api/wallet_manager.cpp,  WalletManagerImpl::connected fail
because is relying on the RPC call get_version